### PR TITLE
Fix a shadowed variable warning

### DIFF
--- a/lib/tdiff/tdiff.rb
+++ b/lib/tdiff/tdiff.rb
@@ -148,7 +148,7 @@ module TDiff
     changes = nil
 
     # recurse down through unchanged nodes
-    unchanged.each { |x,y| x.tdiff_recursive(y,&block) }
+    unchanged.each { |a,b| a.tdiff_recursive(b,&block) }
     unchanged = nil
   end
 end


### PR DESCRIPTION
Not a big deal, but I started testing with RUBYOPT=-w and this showed up.
